### PR TITLE
[FEAT] 사용자 프로필 컴포넌트 구현

### DIFF
--- a/oroom-client/src/components/user/ProfileImage.vue
+++ b/oroom-client/src/components/user/ProfileImage.vue
@@ -1,0 +1,40 @@
+<template>
+  <div>
+    <button
+      class="pointer-events-none border-none font-[Pretendard] font-bold text-[1rem] text-center h-9 w-9 rounded-3xl"
+      :class="buttonClasses"
+    >
+      <slot>{{ text.charAt(0) }}</slot>
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+// Props 정의
+interface Props {
+  variant?: 'default' | 'others'
+  text?: string
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  variant: 'default',
+  text: '',
+})
+
+// Emits 정의
+const emit = defineEmits<{
+  click: [event: MouseEvent]
+}>()
+
+const buttonClasses = computed(() => {
+  if (props.variant === 'others') {
+    return 'gradation bg-gradient-to-l from-[#0AB68B]'
+  }
+  // 기본 버튼
+  return 'gradation bg-gradient-to-r from-[#6C5CE7]'
+})
+</script>
+
+<style scoped></style>

--- a/oroom-client/src/views/TestView.vue
+++ b/oroom-client/src/views/TestView.vue
@@ -2,12 +2,14 @@
   <ButtonItem />
   <DoughnutChart />
   <LabelItem />
+  <ProfileImage />
 </template>
 
 <script setup>
 import DoughnutChart from '@/components/chart/DoughnutChart.vue'
 import ButtonItem from '@/components/button/ButtonItem.vue'
 import LabelItem from '@/components/label/LabelItem.vue'
+import ProfileImage from '@/components/user/ProfileImage.vue'
 </script>
 
 <style scoped></style>


### PR DESCRIPTION
사용자 닉네임 첫 글자를 프로필 이미지에 삽입

<img width="257" height="442" alt="image" src="https://github.com/user-attachments/assets/6590d1f1-f1a6-48e4-a56e-d13e9ae226c0" />

나와 다른 사용자 색상/그라데이션으로 구분