### PR TITLE
[FIX] #35 로그인 화면 요소 크기 수정

### DIFF
--- a/savit-client/src/views/user/Login.vue
+++ b/savit-client/src/views/user/Login.vue
@@ -1,15 +1,15 @@
 <template>
   <div class="min-h-screen bg-gradient-to-t from-[#333333] to-[#0AB68B] flex flex-col">
     <div class="flex-1"></div>
-    <div class="flex-1 flex items-center justify-center">
+    <div class="flex-1 flex items-center justify-center max-w-xs mx-auto">
       <img
         src="@/assets/img/savit_logo.png"
         alt="Savit Logo"
-        class="w-[70%] drop-shadow-[10px_10px_10px_rgba(0,0,0,0.5)]"
+        class="w-full drop-shadow-[10px_10px_10px_rgba(0,0,0,0.5)]"
       />
     </div>
     <div class="flex-1 flex items-end justify-center pb-16">
-      <div class="flex flex-col items-center w-[70%]">
+      <div class="flex flex-col items-center max-w-xs w-full mx-auto">
         <div class="w-full border-t border-[#61A292] mb-8" />
         <img
           src="@/assets/img/kakao_login_medium_wide.png"


### PR DESCRIPTION
- 로그인 화면에 있는 요소들의 크기 고정
( 창의 가로 폭이 최소일 때의 요소들의 크기로 고정)
<img width="622" height="1021" alt="image" src="https://github.com/user-attachments/assets/ed9961e3-81b4-4bf9-87c9-e1460e01b849" />
<img width="1257" height="1012" alt="image" src="https://github.com/user-attachments/assets/db4d0db6-9a81-439c-8eb1-52441973eebc" />

